### PR TITLE
update getRoot function to handle port properly

### DIFF
--- a/service/src/express.js
+++ b/service/src/express.js
@@ -13,9 +13,10 @@ const express = require("express")
   , AuthenticationInitializer = require('./authentication');
 
 const app = express();
+app.enable('trust proxy');
 app.use(function(req, res, next) {
   req.getRoot = function() {
-    return req.protocol + "://" + req.get('host');
+    return req.protocol + "://" + req.hostname;
   };
 
   req.getPath = function() {


### PR DESCRIPTION
The local port is being included in some URLs returned from Mage (e.g. `https://mage.somehost.net:8830/...`), this appears to be happening because `req.get('host')` includes the port. I've updated the `express` config to enable the `trust proxy` option as well as get the "hostname" directly.

This fixed the URL which is generated server side for observation attachments and export downloads

Docs:
- https://expressjs.com/en/guide/behind-proxies.html
- https://expressjs.com/en/api.html#req.hostname